### PR TITLE
Update installenvoy.md

### DIFF
--- a/content/mesh_crystal/installenvoy.md
+++ b/content/mesh_crystal/installenvoy.md
@@ -51,15 +51,6 @@ TASK_DEF_NEW=$(echo $TASK_DEF_OLD \
             "name": "envoy"
           }
         ]' \
-  | jq ' .containerDefinitions[0] +=
-        { 
-          "dependsOn": [ 
-            { 
-              "containerName": "envoy",
-              "condition": "HEALTHY" 
-            }
-          ] 
-        }' \
   | jq ' . += 
         { 
           "proxyConfiguration": {


### PR DESCRIPTION
container dependency not supported in fargate launch type as below:

Note
If you are using tasks that use the Fargate launch type, container dependency parameters are not supported.

https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDependency.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
