### PR TITLE
Fix EKS cluster name  issue

### DIFF
--- a/content/prerequisites/bootstrapsh.md
+++ b/content/prerequisites/bootstrapsh.md
@@ -93,7 +93,7 @@ cat > ~/environment/scripts/build-eks <<-"EOF"
 
 EKS_CLUSTER_NAME=$(jq < cfn-output.json -r '.EKSClusterName')
 
-if [ -z "$EKS_CLUSTER_NAME" ]
+if [ -z "$EKS_CLUSTER_NAME" ] || [ "$EKS_CLUSTER_NAME" == null ]
 then
   
   if ! aws sts get-caller-identity --query Arn | \


### PR DESCRIPTION
build-eks script fails because EKS_CLUSTER_NAME is assigned 'null' as a string

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
