### PR TITLE
Update workspace.md

### DIFF
--- a/content/prerequisites/workspace.md
+++ b/content/prerequisites/workspace.md
@@ -25,6 +25,10 @@ Cloud9 requires third-party-cookies. You can whitelist the [specific domains]( h
 ### Launch Cloud9:
 Create a Cloud9 Environment: [https://us-west-2.console.aws.amazon.com/cloud9/home?region=us-west-2](https://us-west-2.console.aws.amazon.com/cloud9/home?region=us-west-2)
 
+{{% notice warning %}}
+Make sure you are naming your Cloud9 environment `AppMesh-Workshop`, otherwise things will break later.
+{{% /notice %}}
+
 - Select **Create environment**
 - Name it **AppMesh-Workshop**, and take all other defaults
 - When it comes up, customize the environment by closing the **welcome tab**


### PR DESCRIPTION
C9_PROJECT ENV var is used later to define the stackname, if cloud9 project is not called exactly Appmesh-Workshop STACK_NAME env var will be wrong and that breaks a bunch of stuff, we need to remove this dependency in imho

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
