### PR TITLE
Force Helm to Recreate Injector Pod

### DIFF
--- a/content/x-ray/xray_nodejs.md
+++ b/content/x-ray/xray_nodejs.md
@@ -14,7 +14,8 @@ helm upgrade -i appmesh-inject eks/appmesh-inject \
   --set mesh.create=false \
   --set mesh.name=appmesh-workshop \
   --set tracing.enabled=true \
-  --set tracing.provider=x-ray
+  --set tracing.provider=x-ray \
+  --recreate-pods
 ```
 
 Now, let's restart our pods again in order to force the injection of the X-Ray container:


### PR DESCRIPTION
There's a bug in this course whereby Helm will not force the pod to restart and hence cause the X-Ray not to be injected into the NodeJS app.

By adding this flag, we force Helm to restart the injector pod, and thus allow for the expected result.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
