### PR TITLE
add missing step to terminate the ssm session

### DIFF
--- a/content/mesh_nodejs/restart_pods.md
+++ b/content/mesh_nodejs/restart_pods.md
@@ -102,3 +102,9 @@ Node.js backend: Hello! from 10.0.102.185 in AZ-c commit 4252202
 ```
 
 This means that the responses from the NodeJS application are passing in the Envoy proxy.
+
+Now you can terminate the session:
+
+```bash
+exit 
+```


### PR DESCRIPTION
unlike the "mesh the crystal service" and "mesh the frontend service", this page missed the ssm session termination
