### PR TITLE
Fix error in appmesh cleanup script

### DIFF
--- a/content/cleanup/appmesh.md
+++ b/content/cleanup/appmesh.md
@@ -32,7 +32,7 @@ jq -r ' .virtualRouters[] | [.virtualRouterName] | @tsv ' | \
     jq -r ' .routes[] | [ .routeName] | @tsv ' | \
       while IFS=$'\t' read -r routeName; do 
         aws appmesh delete-route \
-          --mesh appmesh-workshop \
+          --mesh-name appmesh-workshop \
           --virtual-router-name $virtualRouterName \
           --route-name $routeName
       done


### PR DESCRIPTION
Correctly specify `--mesh-name` instead of `--mesh`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
