### PR TITLE
delete 2 parameters: registeredBy & registeredAt

### DIFF
--- a/content/deployment/createtaskset.md
+++ b/content/deployment/createtaskset.md
@@ -18,7 +18,7 @@ TASK_DEF_NEW=$(echo $TASK_DEF_OLD \
         if .name=="APPMESH_VIRTUAL_NODE_NAME" then 
               .value="mesh/appmesh-workshop/virtualNode/crystal-sd-epoch" 
         else . end) ' \
-  | jq ' del(.status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision) '
+  | jq ' del(.status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision, .registeredAt, .registeredBy) '
 ); \
 TASK_DEF_FAMILY=$(echo $TASK_DEF_ARN | cut -d"/" -f2 | cut -d":" -f1);
 echo $TASK_DEF_NEW > /tmp/$TASK_DEF_FAMILY.json && 

--- a/content/failures/createtaskset.md
+++ b/content/failures/createtaskset.md
@@ -18,7 +18,7 @@ TASK_DEF_NEW=$(echo $TASK_DEF_OLD \
         if .name=="APPMESH_VIRTUAL_NODE_NAME" then 
               .value="mesh/appmesh-workshop/virtualNode/crystal-sd-error" 
         else . end) ' \
-  | jq ' del(.status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision) '
+  | jq ' del(.status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision, .registeredAt, .registeredBy) '
 ); \
 TASK_DEF_FAMILY=$(echo $TASK_DEF_ARN | cut -d"/" -f2 | cut -d":" -f1);
 echo $TASK_DEF_NEW > /tmp/$TASK_DEF_FAMILY.json && 

--- a/content/mesh_crystal/installenvoy.md
+++ b/content/mesh_crystal/installenvoy.md
@@ -74,7 +74,7 @@ TASK_DEF_NEW=$(echo $TASK_DEF_OLD \
             ]
           }
         }' \
-  | jq ' del(.status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision) '
+  | jq ' del(.status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision, .registeredAt, .registeredBy) '
 ); \
 
 TASK_DEF_FAMILY=$(echo $TASK_DEF_ARN | cut -d"/" -f2 | cut -d":" -f1);

--- a/content/monitoring/monitoringcrystal.md
+++ b/content/monitoring/monitoringcrystal.md
@@ -30,7 +30,7 @@ TASK_DEF_NEW=$(echo $TASK_DEF_OLD \
             }
           }
         else . end) ' \
-  | jq ' del(.status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision) '
+  | jq ' del(.status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision, .registeredAt, .registeredBy) '
 ); \
 TASK_DEF_FAMILY=$(echo $TASK_DEF_ARN | cut -d"/" -f2 | cut -d":" -f1);
 echo $TASK_DEF_NEW > /tmp/$TASK_DEF_FAMILY.json && 

--- a/content/servicediscovery/createservice.md
+++ b/content/servicediscovery/createservice.md
@@ -25,7 +25,7 @@ TASK_DEF_NEW=$(echo $TASK_DEF_OLD \
         if .name=="APPMESH_VIRTUAL_NODE_NAME" then 
               .value="mesh/appmesh-workshop/virtualNode/crystal-sd-vanilla" 
         else . end) ' \
-  | jq ' del(.status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision) '
+  | jq ' del(.status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision, .registeredAt, .registeredBy) '
 ); \
 TASK_DEF_FAMILY=$(echo $TASK_DEF_ARN | cut -d"/" -f2 | cut -d":" -f1);
 echo $TASK_DEF_NEW > /tmp/$TASK_DEF_FAMILY.json && 

--- a/content/x-ray/xraycrystal.md
+++ b/content/x-ray/xraycrystal.md
@@ -49,7 +49,7 @@ TASK_DEF_NEW=$(echo $TASK_DEF_OLD \
             }
           }
         ]' \
-  | jq ' del(.status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision) '
+  | jq ' del(.status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision, .registeredAt, .registeredBy) '
 ); \
 TASK_DEF_FAMILY=$(echo $TASK_DEF_ARN | cut -d"/" -f2 | cut -d":" -f1);
 echo $TASK_DEF_NEW > /tmp/$TASK_DEF_FAMILY.json &&

--- a/scripts/fullrun
+++ b/scripts/fullrun
@@ -289,7 +289,7 @@ add_envoy_sidecar() {
             ]
           }
         }' \
-    | jq ' del( .status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision) '
+    | jq ' del( .status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision, .registeredAt, .registeredBy) '
   ); \
   TASK_DEF_FAMILY=$(echo $TASK_DEF_ARN | cut -d"/" -f2 | cut -d":" -f1);
   echo $TASK_DEF_NEW > /tmp/$TASK_DEF_FAMILY.json && 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix workshop commands. 
Current command causes the error shown as below.

```
workshop:~/environment $ echo $TASK_DEF_NEW > /tmp/$TASK_DEF_FAMILY.json && 
> # Register ecs task definition #
> aws ecs register-task-definition \
>   --cli-input-json file:///tmp/$TASK_DEF_FAMILY.json

Parameter validation failed:
Unknown parameter in input: "registeredBy", must be one of: family, taskRoleArn, executionRoleArn, networkMode, containerDefinitions, volumes, placementConstraints, requiresCompatibilities, cpu, memory, tags, pidMode, ipcMode, proxyConfiguration, inferenceAccelerators
Unknown parameter in input: "registeredAt", must be one of: family, taskRoleArn, executionRoleArn, networkMode, containerDefinitions, volumes, placementConstraints, requiresCompatibilities, cpu, memory, tags, pidMode, ipcMode, proxyConfiguration, inferenceAccelerators
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
