### PR TITLE
Update monitoringcrystal.md

### DIFF
--- a/content/monitoring/monitoringcrystal.md
+++ b/content/monitoring/monitoringcrystal.md
@@ -30,7 +30,7 @@ TASK_DEF_NEW=$(echo $TASK_DEF_OLD \
             }
           }
         else . end) ' \
-  | jq ' del(.status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision) '
+  | jq ' del(.status, .compatibilities, .taskDefinitionArn, .requiresAttributes, .revision, .registeredAt, .registeredBy) '
 ); \
 TASK_DEF_FAMILY=$(echo $TASK_DEF_ARN | cut -d"/" -f2 | cut -d":" -f1);
 echo $TASK_DEF_NEW > /tmp/$TASK_DEF_FAMILY.json && 


### PR DESCRIPTION
The following command produces an error:
```bash
workshop:~/environment $ echo $TASK_DEF_NEW > /tmp/$TASK_DEF_FAMILY.json && 
> # Register ecs task definition #
> aws ecs register-task-definition \
>   --cli-input-json file:///tmp/$TASK_DEF_FAMILY.json

Parameter validation failed:
Unknown parameter in input: "registeredBy", must be one of: family, taskRoleArn, executionRoleArn, networkMode, containerDefinitions, volumes, placementConstraints, requiresCompatibilities, cpu, memory, tags, pidMode, ipcMode, proxyConfiguration, inferenceAccelerators
Unknown parameter in input: "registeredAt", must be one of: family, taskRoleArn, executionRoleArn, networkMode, containerDefinitions, volumes, placementConstraints, requiresCompatibilities, cpu, memory, tags, pidMode, ipcMode, proxyConfiguration, inferenceAccelerators 
```
*Description of changes:*
Removing unknown parameters **registeredAt** and **registeredBy** from new task definition for **[ecs register-task-definition](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RegisterTaskDefinition.html)** request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.